### PR TITLE
Added substream bracketing around csv records

### DIFF
--- a/components/csv/component.wick
+++ b/components/csv/component.wick
@@ -7,7 +7,7 @@ package:
     host: 'registry.candle.dev'
     namespace: 'common'
 metadata:
-  version: 0.0.1
+  version: 0.0.2
 import: []
 component:
   kind: wick/component/wasmrs@v1

--- a/components/csv/component.wick
+++ b/components/csv/component.wick
@@ -7,7 +7,7 @@ package:
     host: 'registry.candle.dev'
     namespace: 'common'
 metadata:
-  version: 0.0.2
+  version: 0.0.3
 import: []
 component:
   kind: wick/component/wasmrs@v1
@@ -26,13 +26,7 @@ tests:
         operation: parse_bytes
         inputs:
           - name: input
-            flags:
-              open: true
-          - name: input
             value: "{{ '1,1,1\n2,2,2' | base64_encode }}"
-          - name: input
-            flags:
-              close: true
         outputs:
           - name: output
             flags:

--- a/components/csv/src/lib.rs
+++ b/components/csv/src/lib.rs
@@ -80,12 +80,14 @@ async fn handle_packet(
         .has_headers(false)
         .from_reader(input.as_ref());
 
+    outputs.output.open_bracket();
     for result in rdr.records() {
         let record = result.unwrap();
 
         let fields: Vec<String> = record.deserialize(None).unwrap();
         outputs.output.send(&fields);
     }
+    outputs.output.close_bracket();
 
     Ok(())
 }


### PR DESCRIPTION
The previous version didn't have any context around the inner records. This PR brackets them so they can be treated as a group.