### PR TITLE
Azure substreams

### DIFF
--- a/components/azureblob/azureblob.wick
+++ b/components/azureblob/azureblob.wick
@@ -1,7 +1,7 @@
 kind: wick/component@v1
 name: azureblob
 metadata:
-  version: 0.4.0
+  version: 0.5.0
   description: Access files on azure blob storage
   licenses:
     - Apache-2.0
@@ -23,6 +23,10 @@ import:
       ref: registry.candle.dev/common/hmac:0.3.0
       with:
         secret: '{{ ctx.root_config.access_key }}'
+  - name: liquid
+    component:
+      kind: wick/component/manifest@v1
+      ref: registry.candle.dev/common/liquid:0.3.0
   - name: string
     component:
       kind: wick/component/manifest@v1
@@ -42,15 +46,12 @@ component:
         - name: resource
           type: string
       uses:
-        - name: AUTH_PAYLOAD_PREFIX
-          operation: core::sender
+        - name: AUTH_PAYLOAD
+          operation: liquid::render
           with:
-            output: "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:{{ ctx.inherent.timestamp | date: '%a, %d %b %Y %H:%M:00' }} GMT\nx-ms-version:2011-08-18\n/{{ctx.root_config.storage_account}}/{{ctx.root_config.container_name}}/"
+            template: "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:{{ ctx.inherent.timestamp | date: '%a, %d %b %Y %H:%M:00' }} GMT\nx-ms-version:2011-08-18\n/{{ctx.root_config.storage_account}}/{{ctx.root_config.container_name}}/{%raw%}{{input}}{%endraw%}"
       flow:
-        - AUTH_PAYLOAD_PREFIX.output -> string::concatenate[a].left
-        - <>.resource -> a.right
-        - a.output -> hmac::from_string[b].input
-        - b.output -> azureblob::get[c].authorization
+        - <>.resource -> AUTH_PAYLOAD -> hmac::from_string -> azureblob::get[c].authorization
         - <>.resource -> c.resource
         - c.response -> <>.response
         - c.body -> <>.output

--- a/components/liquid/build.rs
+++ b/components/liquid/build.rs
@@ -1,5 +1,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=liquid.wick");
-    wick_component_codegen::configure().generate("liquid.wick")?;
+    wick_component_codegen::configure()
+        .raw(true)
+        .generate("liquid.wick")?;
     Ok(())
 }

--- a/components/liquid/liquid.wick
+++ b/components/liquid/liquid.wick
@@ -7,7 +7,7 @@ metadata:
   authors: ['Candle Corporation']
   licenses: ['Apache-2.0']
   documentation: Source code available at https://github.com/candlecorp/wick-components/tree/main/components.  Liquid template documentation available at https://shopify.github.io/liquid/.
-  version: '0.2.0'
+  version: '0.3.0'
 package:
   registry:
     host: registry.candle.dev
@@ -21,7 +21,7 @@ component:
         - name: template
           type: string
       inputs:
-        - name: parameters
+        - name: context
           type: object
       outputs:
         - name: output
@@ -31,13 +31,41 @@ tests:
       - name: liquid
         operation: render
         with:
-          template: 'This is a {%raw%}{{ adjective }}{%endraw%} string.  It is {%raw%}{{ length }}{%endraw%} very long.'
+          template: '{%raw%}This is a {{ input.adjective }} string. It is {{ input.length }} very long.{%endraw%}'
         inputs:
-          - name: parameters
+          - name: context
             value: { 'adjective': 'nice', 'length': 'not' }
         outputs:
           - name: output
-            value: 'This is a nice string.  It is not very long.'
+            value: 'This is a nice string. It is not very long.'
+      - name: liquid
+        operation: render
+        with:
+          template: '{%raw%}I passed in a value of "{{ input }}".{%endraw%}'
+        inputs:
+          - name: context
+            value: 'Simple String'
+        outputs:
+          - name: output
+            value: 'I passed in a value of "Simple String".'
+      - name: liquid
+        operation: render
+        with:
+          template: '{%raw%}This is a {{ input.adjective }} string. It is {{ input.length }} very long.{%endraw%}'
+        inputs:
+          - name: context
+            flag: Open
+          - name: context
+            value: { 'adjective': 'nice', 'length': 'not' }
+          - name: context
+            flag: Close
+        outputs:
+          - name: output
+            flag: Open
+          - name: output
+            value: 'This is a nice string. It is not very long.'
+          - name: output
+            flag: Close
           - name: output
             flags:
               done: true

--- a/components/liquid/src/lib.rs
+++ b/components/liquid/src/lib.rs
@@ -6,48 +6,25 @@ mod wick {
 }
 use wick::*;
 
-#[cfg_attr(target_family = "wasm",async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
-impl render::Operation for Component {
-    type Error = anyhow::Error;
-    type Outputs = render::Outputs;
-    type Config = render::Config;
-    async fn render(
-        mut input: WickStream<Value>,
-        mut outputs: Self::Outputs,
-        ctx: Context<Self::Config>,
-    ) -> anyhow::Result<()> {
-        let template_string = ctx.config.template.clone();
-        println!("Template: {:?}", template_string);
+#[wick_component::operation(unary_simple)]
+fn render(input: Value, ctx: Context<render::Config>) -> Result<String, anyhow::Error> {
+    // Create a Liquid parser
+    let parser = ParserBuilder::with_stdlib().build().unwrap();
 
-        // Create a Liquid parser
-        let parser = ParserBuilder::with_stdlib().build().unwrap();
+    // Parse the template string
+    let liquid_template = match parser.parse(&ctx.config.template) {
+        Ok(t) => t,
+        Err(e) => return Err(anyhow::anyhow!("Invalid template string: {}", e)),
+    };
 
-        while let Some(Ok(input)) = input.next().await {
-            // Parse the template string
-            let liquid_template = match parser.parse(&template_string) {
-                Ok(t) => t,
-                Err(e) => return Err(anyhow::anyhow!("Invalid template string: {}", e)),
-            };
+    let context = liquid::object!({"input": input});
 
-            println!("params: {:?}", input);
+    // Render the template with the provided parameters
+    let rendered = match liquid_template.render(&context) {
+        Ok(r) => r,
+        Err(e) => return Err(anyhow::anyhow!("Error rendering template: {}", e)),
+    };
 
-            let globals = liquid::object!(&input);
-
-            println!("globals: {:?}", globals);
-
-            // Render the template with the provided parameters
-            let rendered = match liquid_template.render(&globals) {
-                Ok(r) => r,
-                Err(e) => return Err(anyhow::anyhow!("Error rendering template: {}", e)),
-            };
-
-            // Send the rendered string to the output
-            outputs.output.send(&rendered);
-        }
-
-        // Signal that the output stream is done
-        outputs.output.done();
-        Ok(())
-    }
+    // Send the rendered string to the output
+    Ok(rendered)
 }


### PR DESCRIPTION
The azure blob component would fail on substreams because of its naive use of `core::sender` to create the auth blob. This update uses the `liquid` component to render the string sent to HMAC.

The PR also updates `liquid` to better support being passed simple value types.